### PR TITLE
Set NFS V3 Drivers to be configurable with whitelist config options by Bosh Operator

### DIFF
--- a/nfs_v3_config.go
+++ b/nfs_v3_config.go
@@ -1,0 +1,350 @@
+package nfsv3driver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ConfigDetails struct {
+	Allowed   []string
+	Mandatory []string
+
+	Forced  map[string]string
+	Options map[string]string
+}
+
+type Config struct {
+	source      ConfigDetails
+	mount       ConfigDetails
+	sloppyMount bool
+}
+
+func inArray(list []string, key string) bool {
+	for _, k := range list {
+		if k == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+func NewNfsV3Config(sourceDetails *ConfigDetails, mountDetails *ConfigDetails) *Config {
+	myConf := new(Config)
+
+	myConf.source = *sourceDetails
+	myConf.mount = *mountDetails
+	myConf.sloppyMount = false
+
+	return myConf
+}
+
+func NewNfsV3ConfigDetails() *ConfigDetails {
+	myConf := new(ConfigDetails)
+
+	myConf.Allowed = make([]string, 0)
+	myConf.Options = make(map[string]string, 0)
+	myConf.Forced = make(map[string]string, 0)
+	myConf.Mandatory = make([]string, 0)
+
+	return myConf
+}
+
+func (m *Config) SetEntries(share string, opts map[string]interface{}, ignoreList []string) error {
+
+	m.source.parseMap(opts, ignoreList)
+	m.mount.parseMap(opts, ignoreList)
+
+	allowed := append(ignoreList, m.source.Allowed...)
+	allowed = append(allowed, m.mount.Allowed...)
+	errorList := m.source.parseUrl(share, ignoreList)
+	m.sloppyMount = m.mount.IsSloppyMount()
+
+	for k, _ := range opts {
+		if !inArray(allowed, k) {
+			errorList = append(errorList, k)
+		}
+	}
+
+	if len(errorList) > 0 && m.sloppyMount != true {
+		err := errors.New("Not allowed options : " + strings.Join(errorList, ", "))
+		return err
+	}
+
+	if mdtErr := append(m.source.CheckMandatory(), m.mount.CheckMandatory()...); len(mdtErr) > 0 {
+		err := errors.New("Missing mandatory options : " + strings.Join(mdtErr, ", "))
+		return err
+	}
+
+	return nil
+}
+
+func (m Config) Share(share string) string {
+
+	srcPart := strings.SplitN(share, "?", 2)
+
+	if len(srcPart) < 2 {
+		srcPart = append(srcPart, "")
+	}
+
+	srcPart[1] = strings.Join(m.source.makeParams(""), "&")
+
+	if len(srcPart[1]) < 1 {
+		srcPart = srcPart[:len(srcPart)-1]
+	}
+
+	return strings.Join(srcPart, "?")
+}
+
+func (m Config) Mount() []string {
+
+	return m.mount.makeParams("--")
+}
+
+func (m Config) MountConfig() map[string]interface{} {
+
+	return m.mount.makeConfig()
+}
+
+func (m *ConfigDetails) readConfAllowed(flagString string) error {
+	if len(flagString) > 0 {
+		m.Allowed = strings.Split(flagString, ",")
+	}
+
+	return nil
+}
+
+func (m *ConfigDetails) readConfDefault(flagString string) error {
+	if len(flagString) < 1 {
+		return nil
+	}
+
+	m.Options = m.parseConfig(strings.Split(flagString, ","))
+	m.Forced = make(map[string]string)
+
+	for k, v := range m.Options {
+		if !inArray(m.Allowed, k) {
+			m.Forced[k] = v
+			delete(m.Options, k)
+		}
+	}
+
+	return nil
+}
+
+func (m *ConfigDetails) ReadConf(allowedFlag string, defaultFlag string, mandatoryFields []string) error {
+	if err := m.readConfAllowed(allowedFlag); err != nil {
+		return err
+	}
+
+	if err := m.readConfDefault(defaultFlag); err != nil {
+		return err
+	}
+
+	if len(mandatoryFields) > 0 {
+		m.Mandatory = mandatoryFields
+	}
+
+	return nil
+}
+
+func (m ConfigDetails) CheckMandatory() []string {
+	var result []string
+
+	for _, k := range m.Mandatory {
+
+		_, oko := m.Options[k]
+		_, okf := m.Forced[k]
+
+		if !okf && !oko {
+			result = append(result, k)
+		}
+	}
+
+	return result
+}
+
+func (m ConfigDetails) parseConfig(listEntry []string) map[string]string {
+
+	result := map[string]string{}
+
+	for _, opt := range listEntry {
+
+		key := strings.SplitN(opt, ":", 2)
+
+		if len(key[0]) < 1 {
+			continue
+		}
+
+		if len(key[1]) < 1 {
+			result[key[0]] = ""
+		} else {
+			result[key[0]] = key[1]
+		}
+	}
+
+	return result
+}
+
+func (m *ConfigDetails) IsSloppyMount() bool {
+
+	spm := ""
+	ok := false
+
+	if _, ok = m.Options["sloppy_mount"]; ok {
+		spm = m.Options["sloppy_mount"]
+		delete(m.Options, "sloppy_mount")
+	}
+
+	if _, ok = m.Forced["sloppy_mount"]; ok {
+		spm = m.Forced["sloppy_mount"]
+		delete(m.Forced, "sloppy_mount")
+	}
+
+	if len(spm) > 0 {
+		if val, err := strconv.ParseBool(spm); err == nil {
+			return val
+		}
+	}
+
+	return false
+}
+
+func (m ConfigDetails) uniformKeyData(key string, data interface{}) string {
+	switch key {
+	case "auto-traverse-mounts":
+		return m.uniformData(data, true)
+
+	case "dircache":
+		return m.uniformData(data, true)
+
+	}
+
+	return m.uniformData(data, false)
+}
+
+func (m ConfigDetails) uniformData(data interface{}, boolAsInt bool) string {
+
+	switch data.(type) {
+	case int:
+		return strconv.FormatInt(int64(data.(int)), 10)
+
+	case string:
+		return data.(string)
+
+	case bool:
+		if boolAsInt {
+			if data.(bool) {
+				return "1"
+			} else {
+				return "0"
+			}
+		} else {
+			return strconv.FormatBool(data.(bool))
+		}
+	}
+
+	return ""
+}
+
+func (m *ConfigDetails) parseUrl(url string, ignoreList []string) []string {
+
+	var errorList []string
+
+	part := strings.SplitN(url, "?", 2)
+
+	if len(part) < 2 {
+		part = append(part, "")
+	}
+
+	for _, p := range strings.Split(part[1], "&") {
+		if key := m.parseUrlParams(p, ignoreList); len(key) > 0 {
+			errorList = append(errorList, key)
+		}
+
+	}
+
+	return errorList
+}
+
+func (m *ConfigDetails) parseUrlParams(urlParams string, ignoreList []string) string {
+
+	op := strings.SplitN(urlParams, "=", 2)
+
+	if len(op) < 2 || len(op[1]) < 1 || op[1] == "" || inArray(ignoreList, op[0]) {
+		return ""
+	}
+
+	if inArray(m.Allowed, op[0]) {
+		m.Options[op[0]] = m.uniformKeyData(op[0], op[1])
+		return ""
+	}
+
+	return op[0]
+}
+
+func (m *ConfigDetails) parseMap(entryList map[string]interface{}, ignoreList []string) []string {
+
+	var errorList []string
+
+	for k, v := range entryList {
+
+		value := m.uniformData(v, false)
+
+		if value == "" || len(k) < 1 || inArray(ignoreList, k) {
+			continue
+		}
+
+		if inArray(m.Allowed, k) {
+			m.Options[k] = value
+		} else {
+			errorList = append(errorList, k)
+		}
+	}
+
+	return errorList
+}
+
+func (m ConfigDetails) makeParams(prefix string) []string {
+	params := []string{}
+
+	for k, v := range m.makeConfig() {
+
+		if k == "sloppy_mount" {
+			continue
+		}
+
+		if val, err := strconv.ParseBool(v.(string)); err == nil {
+			if val {
+				params = append(params, fmt.Sprintf("%s%s", prefix, k))
+			}
+			continue
+		}
+
+		if val, err := strconv.ParseInt(v.(string), 10, 16); err == nil {
+			params = append(params, fmt.Sprintf("%s%s=%d", prefix, k, val))
+			continue
+		}
+
+		params = append(params, fmt.Sprintf("%s%s=%s", prefix, k, v.(string)))
+	}
+
+	return params
+}
+
+func (m *ConfigDetails) makeConfig() map[string]interface{} {
+
+	params := map[string]interface{}{}
+
+	for k, v := range m.Options {
+		params[k] = v
+	}
+
+	for k, v := range m.Forced {
+		params[k] = v
+	}
+
+	return params
+}

--- a/nfs_v3_config_test.go
+++ b/nfs_v3_config_test.go
@@ -1,0 +1,598 @@
+package nfsv3driver_test
+
+import (
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagertest"
+	. "code.cloudfoundry.org/nfsv3driver"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"strconv"
+	"strings"
+)
+
+func map2string(entry map[string]string, joinKeyVal string, prefix string, joinElemnts string) string {
+	return strings.Join(map2slice(entry, joinKeyVal, prefix), joinElemnts)
+}
+
+func mapstring2mapinterface(entry map[string]string) map[string]interface{} {
+	result := make(map[string]interface{}, 0)
+
+	for k, v := range entry {
+		result[k] = v
+	}
+
+	return result
+}
+
+func map2slice(entry map[string]string, joinKeyVal string, prefix string) []string {
+	result := make([]string, 0)
+
+	for k, v := range entry {
+		result = append(result, fmt.Sprintf("%s%s%s%s", prefix, k, joinKeyVal, v))
+	}
+
+	return result
+}
+
+func mapint2slice(entry map[string]interface{}, joinKeyVal string, prefix string) []string {
+	result := make([]string, 0)
+
+	for k, v := range entry {
+		switch v.(type) {
+		case int:
+			result = append(result, fmt.Sprintf("%s%s%s%s", prefix, k, joinKeyVal, strconv.FormatInt(int64(v.(int)), 10)))
+
+		case string:
+			result = append(result, fmt.Sprintf("%s%s%s%s", prefix, k, joinKeyVal, v.(string)))
+
+		case bool:
+			result = append(result, fmt.Sprintf("%s%s%s%s", prefix, k, joinKeyVal, strconv.FormatBool(v.(bool))))
+		}
+
+	}
+
+	return result
+}
+
+func inSliceString(list []string, val string) bool {
+	for _, v := range list {
+		if v == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+func inMapInt(list map[string]interface{}, key string, val interface{}) bool {
+	for k, v := range list {
+		if k != key {
+			continue
+		}
+
+		if v == val {
+			return true
+		} else {
+			return false
+		}
+	}
+
+	return false
+}
+
+var _ = Describe("BrokerConfigDetails", func() {
+	var (
+		logger lager.Logger
+
+		ClientShare     string
+		AbitraryConfig  map[string]interface{}
+		IgnoreConfigKey []string
+
+		SourceAllowed   []string
+		SourceOptions   map[string]string
+		SourceMandatory []string
+
+		MountsAllowed   []string
+		MountsOptions   map[string]string
+		MountsMandatory []string
+
+		source *ConfigDetails
+		mounts *ConfigDetails
+		config *Config
+
+		errorEntries error
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("test-broker-config")
+	})
+
+	Context("Given no mandatory and empty params", func() {
+		BeforeEach(func() {
+			ClientShare = "nfs://1.2.3.4"
+			AbitraryConfig = make(map[string]interface{}, 0)
+			IgnoreConfigKey = make([]string, 0)
+
+			SourceAllowed = make([]string, 0)
+			SourceOptions = make(map[string]string, 0)
+			SourceMandatory = make([]string, 0)
+
+			MountsAllowed = make([]string, 0)
+			MountsOptions = make(map[string]string, 0)
+			MountsMandatory = make([]string, 0)
+
+			source = NewNfsV3ConfigDetails()
+			source.ReadConf(strings.Join(SourceAllowed, ","), map2string(SourceOptions, ":", "", ","), SourceMandatory)
+
+			mounts = NewNfsV3ConfigDetails()
+			mounts.ReadConf(strings.Join(MountsAllowed, ","), map2string(MountsOptions, ":", "", ","), MountsMandatory)
+
+			config = NewNfsV3Config(source, mounts)
+			logger.Debug("Debug config Initiated", lager.Data{"source": source, "mount": mounts})
+
+			errorEntries = config.SetEntries(ClientShare, AbitraryConfig, IgnoreConfigKey)
+			logger.Debug("Debug config updated", lager.Data{"source": source, "mount": mounts})
+		})
+
+		It("should returns empty allowed list", func() {
+			Expect(len(source.Allowed)).To(Equal(0))
+			Expect(len(mounts.Allowed)).To(Equal(0))
+		})
+
+		It("should returns empty forced list", func() {
+			Expect(len(source.Forced)).To(Equal(0))
+			Expect(len(mounts.Forced)).To(Equal(0))
+		})
+
+		It("should returns empty options list", func() {
+			Expect(len(source.Options)).To(Equal(0))
+			Expect(len(mounts.Options)).To(Equal(0))
+		})
+
+		It("should flow sloppy_mount as disabled", func() {
+			Expect(source.IsSloppyMount()).To(BeFalse())
+			Expect(mounts.IsSloppyMount()).To(BeFalse())
+		})
+
+		It("should returns no missing mandatory fields", func() {
+			Expect(len(source.CheckMandatory())).To(Equal(0))
+			Expect(len(mounts.CheckMandatory())).To(Equal(0))
+		})
+
+		It("should returns no error on given client abitrary config", func() {
+			Expect(errorEntries).To(BeNil())
+		})
+
+		It("should returns no mount command parameters", func() {
+			Expect(len(config.Mount())).To(Equal(0))
+		})
+
+		It("should returns no MountOptions struct", func() {
+			Expect(len(config.MountConfig())).To(Equal(0))
+		})
+
+		It("returns no added parameters to the client share", func() {
+			Expect(config.Share(ClientShare)).To(Equal(ClientShare))
+		})
+	})
+
+	Context("Given source mandatory, no mount mandatory and empty params", func() {
+		BeforeEach(func() {
+			ClientShare = "nfs://1.2.3.4"
+			AbitraryConfig = make(map[string]interface{}, 0)
+			IgnoreConfigKey = make([]string, 0)
+
+			SourceAllowed = make([]string, 0)
+			SourceOptions = make(map[string]string, 0)
+			SourceMandatory = []string{"uid", "gid"}
+
+			MountsAllowed = make([]string, 0)
+			MountsOptions = make(map[string]string, 0)
+			MountsMandatory = make([]string, 0)
+
+			source = NewNfsV3ConfigDetails()
+			source.ReadConf(strings.Join(SourceAllowed, ","), map2string(SourceOptions, ":", "", ","), SourceMandatory)
+
+			mounts = NewNfsV3ConfigDetails()
+			mounts.ReadConf(strings.Join(MountsAllowed, ","), map2string(MountsOptions, ":", "", ","), MountsMandatory)
+
+			config = NewNfsV3Config(source, mounts)
+			logger.Debug("Debug config Initiated", lager.Data{"source": source, "mount": mounts})
+
+			errorEntries = config.SetEntries(ClientShare, AbitraryConfig, IgnoreConfigKey)
+			logger.Debug("Debug config updated", lager.Data{"config": config, "source": source, "mount": mounts})
+		})
+
+		It("should returns empty allowed list", func() {
+			Expect(len(source.Allowed)).To(Equal(0))
+			Expect(len(mounts.Allowed)).To(Equal(0))
+		})
+
+		It("should returns empty forced list", func() {
+			Expect(len(source.Forced)).To(Equal(0))
+			Expect(len(mounts.Forced)).To(Equal(0))
+		})
+
+		It("should returns empty options list", func() {
+			Expect(len(source.Options)).To(Equal(0))
+			Expect(len(mounts.Options)).To(Equal(0))
+		})
+
+		It("should flow sloppy_mount as disabled", func() {
+			Expect(source.IsSloppyMount()).To(BeFalse())
+			Expect(mounts.IsSloppyMount()).To(BeFalse())
+		})
+
+		It("should returns no missing mount mandatory fields", func() {
+			Expect(len(mounts.CheckMandatory())).To(Equal(0))
+		})
+
+		It("should flow the mandatory config as missing mandatory field", func() {
+			Expect(len(source.CheckMandatory())).To(Equal(2))
+			Expect(source.CheckMandatory()).To(Equal(SourceMandatory))
+		})
+
+		It("should occures an error because there are missing fields", func() {
+			Expect(errorEntries).To(HaveOccurred())
+		})
+
+		It("should returns no mount command parameters", func() {
+			Expect(len(config.Mount())).To(Equal(0))
+		})
+
+		It("should returns no MountOptions struct", func() {
+			Expect(len(config.MountConfig())).To(Equal(0))
+		})
+
+		It("should returns no added parameters to the client share", func() {
+			Expect(config.Share(ClientShare)).To(Equal(ClientShare))
+		})
+	})
+
+	Context("Given mandatory, allowed and default params", func() {
+		BeforeEach(func() {
+			ClientShare = "nfs://1.2.3.4"
+			AbitraryConfig = make(map[string]interface{}, 0)
+			IgnoreConfigKey = make([]string, 0)
+
+			SourceAllowed = []string{"uid", "gid"}
+			SourceMandatory = []string{"uid", "gid"}
+			SourceOptions = map[string]string{
+				"uid": "1004",
+				"gid": "1002",
+			}
+
+			MountsAllowed = []string{"sloppy_mount", "nfs_uid", "nfs_gid"}
+			MountsMandatory = make([]string, 0)
+			MountsOptions = map[string]string{
+				"nfs_uid": "1003",
+				"nfs_gid": "1001",
+			}
+
+			source = NewNfsV3ConfigDetails()
+			source.ReadConf(strings.Join(SourceAllowed, ","), map2string(SourceOptions, ":", "", ","), SourceMandatory)
+
+			mounts = NewNfsV3ConfigDetails()
+			mounts.ReadConf(strings.Join(MountsAllowed, ","), map2string(MountsOptions, ":", "", ","), MountsMandatory)
+
+			config = NewNfsV3Config(source, mounts)
+			logger.Debug("Debug config Initiated", lager.Data{"config": config, "source": source, "mount": mounts})
+		})
+
+		It("should flow the allowed list", func() {
+			Expect(source.Allowed).To(Equal(SourceAllowed))
+			Expect(mounts.Allowed).To(Equal(MountsAllowed))
+		})
+
+		It("should return empty forced list", func() {
+			Expect(len(source.Forced)).To(Equal(0))
+			Expect(len(mounts.Forced)).To(Equal(0))
+		})
+
+		It("should flow the default params as options list", func() {
+			Expect(source.Options).To(Equal(SourceOptions))
+			Expect(mounts.Options).To(Equal(MountsOptions))
+		})
+
+		It("should flow sloppy_mount as disabled", func() {
+			Expect(source.IsSloppyMount()).To(BeFalse())
+			Expect(mounts.IsSloppyMount()).To(BeFalse())
+		})
+
+		It("should return empty missing mandatory field", func() {
+			Expect(len(source.CheckMandatory())).To(Equal(0))
+			Expect(len(mounts.CheckMandatory())).To(Equal(0))
+		})
+
+		Context("Given empty abitrary params and share without any params", func() {
+			BeforeEach(func() {
+				errorEntries = config.SetEntries(ClientShare, AbitraryConfig, IgnoreConfigKey)
+				logger.Debug("Debug config updated", lager.Data{"config": config, "source": source, "mount": mounts})
+			})
+
+			It("should return nil result on setting end users'entries", func() {
+				Expect(errorEntries).To(BeNil())
+			})
+
+			It("flow the mount default options into the mount command parameters ", func() {
+				actualRes := config.Mount()
+				expectRes := map2slice(MountsOptions, "=", "--")
+
+				for _, exp := range expectRes {
+					logger.Debug("Checking actualRes contain part", lager.Data{"actualRes": actualRes, "part": exp})
+					Expect(inSliceString(actualRes, exp)).To(BeTrue())
+				}
+
+				for _, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "part": exp})
+					Expect(inSliceString(expectRes, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the mount default options into the MountOptions struct", func() {
+				actualRes := config.MountConfig()
+				expectRes := mapstring2mapinterface(MountsOptions)
+
+				for k, exp := range expectRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(actualRes, k, exp)).To(BeTrue())
+				}
+
+				for k, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(expectRes, k, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the source default options as parameters into the client share url", func() {
+
+				share := config.Share(ClientShare)
+				Expect(share).To(ContainSubstring(ClientShare + "?"))
+
+				for _, exp := range map2slice(SourceOptions, "=", "") {
+					logger.Debug("Checking Share contain part", lager.Data{"share": share, "part": exp})
+					Expect(share).To(ContainSubstring(exp))
+				}
+			})
+		})
+
+		Context("Given bad abitrary params and bad share params", func() {
+
+			BeforeEach(func() {
+				ClientShare = "nfs://1.2.3.4?err=true&test=err"
+				AbitraryConfig = map[string]interface{}{
+					"missing": true,
+					"wrong":   1234,
+					"search":  "notfound",
+				}
+				IgnoreConfigKey = make([]string, 0)
+
+				errorEntries = config.SetEntries(ClientShare, AbitraryConfig, IgnoreConfigKey)
+				logger.Debug("Debug config updated", lager.Data{"config": config, "source": source, "mount": mounts})
+			})
+
+			It("should occured an error", func() {
+				Expect(errorEntries).To(HaveOccurred())
+				logger.Debug("Debug config updated with entry", lager.Data{"config": config, "source": source, "mount": mounts})
+			})
+
+			It("should flow the mount default options into the mount command parameters ", func() {
+				actualRes := config.Mount()
+				expectRes := map2slice(MountsOptions, "=", "--")
+
+				for _, exp := range expectRes {
+					logger.Debug("Checking actualRes contain part", lager.Data{"actualRes": actualRes, "part": exp})
+					Expect(inSliceString(actualRes, exp)).To(BeTrue())
+				}
+
+				for _, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "part": exp})
+					Expect(inSliceString(expectRes, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the mount default options into the MountOptions struct", func() {
+				actualRes := config.MountConfig()
+				expectRes := mapstring2mapinterface(MountsOptions)
+
+				for k, exp := range expectRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(actualRes, k, exp)).To(BeTrue())
+				}
+
+				for k, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(expectRes, k, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the source default options as parameters into the client share url", func() {
+
+				share := config.Share(ClientShare)
+				Expect(share).To(ContainSubstring("nfs://1.2.3.4?"))
+
+				for _, exp := range map2slice(SourceOptions, "=", "") {
+					logger.Debug("Checking Share contain part", lager.Data{"share": share, "part": exp})
+					Expect(share).To(ContainSubstring(exp))
+				}
+			})
+		})
+
+		Context("Given bad abitrary params and bad share params with sloppy_mount mode", func() {
+
+			BeforeEach(func() {
+				ClientShare = "nfs://1.2.3.4?err=true&test=err"
+				AbitraryConfig = map[string]interface{}{
+					"sloppy_mount": true,
+					"missing":      true,
+					"wrong":        1234,
+					"search":       "notfound",
+				}
+				IgnoreConfigKey = make([]string, 0)
+
+				errorEntries = config.SetEntries(ClientShare, AbitraryConfig, IgnoreConfigKey)
+				logger.Debug("Debug config updated", lager.Data{"config": config, "source": source, "mount": mounts})
+			})
+
+			It("should not occured an error, return nil", func() {
+				Expect(errorEntries).To(BeNil())
+				logger.Debug("Debug config updated with entry", lager.Data{"config": config, "source": source, "mount": mounts})
+			})
+
+			It("should flow the mount default options into the mount command parameters ", func() {
+				actualRes := config.Mount()
+				expectRes := map2slice(MountsOptions, "=", "--")
+
+				for _, exp := range expectRes {
+					logger.Debug("Checking actualRes contain part", lager.Data{"actualRes": actualRes, "part": exp})
+					Expect(inSliceString(actualRes, exp)).To(BeTrue())
+				}
+
+				for _, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "part": exp})
+					Expect(inSliceString(expectRes, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the mount default options into the MountOptions struct", func() {
+				actualRes := config.MountConfig()
+				expectRes := mapstring2mapinterface(MountsOptions)
+
+				for k, exp := range expectRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(actualRes, k, exp)).To(BeTrue())
+				}
+
+				for k, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(expectRes, k, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the source default options as parameters into the client share url", func() {
+
+				share := config.Share(ClientShare)
+				Expect(share).To(ContainSubstring("nfs://1.2.3.4?"))
+
+				for _, exp := range map2slice(SourceOptions, "=", "") {
+					logger.Debug("Checking Share contain part", lager.Data{"share": share, "part": exp})
+					Expect(share).To(ContainSubstring(exp))
+				}
+			})
+		})
+
+		Context("Given good abitrary params and good share params", func() {
+
+			BeforeEach(func() {
+				ClientShare = "nfs://1.2.3.4?uid=2999&gid=1999"
+				AbitraryConfig = map[string]interface{}{
+					"nfs_uid": "1234",
+					"nfs_gid": "5678",
+				}
+				IgnoreConfigKey = make([]string, 0)
+
+				errorEntries = config.SetEntries(ClientShare, AbitraryConfig, IgnoreConfigKey)
+				logger.Debug("Debug config updated", lager.Data{"config": config, "source": source, "mount": mounts})
+			})
+
+			It("should not occured an error, return nil", func() {
+				Expect(errorEntries).To(BeNil())
+			})
+
+			It("should flow the arbitrary config into the mount command parameters ", func() {
+				actualRes := config.Mount()
+				expectRes := mapint2slice(AbitraryConfig, "=", "--")
+
+				for _, exp := range expectRes {
+					logger.Debug("Checking actualRes contain part", lager.Data{"actualRes": actualRes, "part": exp})
+					Expect(inSliceString(actualRes, exp)).To(BeTrue())
+				}
+
+				for _, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "part": exp})
+					Expect(inSliceString(expectRes, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the arbitrary config into the MountOptions struct", func() {
+				actualRes := config.MountConfig()
+				expectRes := AbitraryConfig
+
+				for k, exp := range expectRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(actualRes, k, exp)).To(BeTrue())
+				}
+
+				for k, exp := range actualRes {
+					logger.Debug("Checking expectRes contain part", lager.Data{"expectRes": expectRes, "key": k, "val": exp})
+					Expect(inMapInt(expectRes, k, exp)).To(BeTrue())
+				}
+			})
+
+			It("should flow the source default options overrided by the share good params into the mount share url", func() {
+				share := config.Share(ClientShare)
+
+				Expect(share).To(ContainSubstring("nfs://1.2.3.4?"))
+				Expect(share).To(ContainSubstring("uid=2999"))
+				Expect(share).To(ContainSubstring("gid=1999"))
+			})
+		})
+	})
+
+	Context("Given mandatory and default params but with empty allowed", func() {
+		BeforeEach(func() {
+			ClientShare = "nfs://1.2.3.4"
+			AbitraryConfig = make(map[string]interface{}, 0)
+			IgnoreConfigKey = make([]string, 0)
+
+			SourceAllowed = make([]string, 0)
+			SourceMandatory = []string{"uid", "gid"}
+			SourceOptions = map[string]string{
+				"uid": "1004",
+				"gid": "1002",
+			}
+
+			MountsAllowed = make([]string, 0)
+			MountsMandatory = make([]string, 0)
+			MountsOptions = map[string]string{
+				"auto_cache": "true",
+			}
+
+			source = NewNfsV3ConfigDetails()
+			source.ReadConf(strings.Join(SourceAllowed, ","), map2string(SourceOptions, ":", "", ","), SourceMandatory)
+
+			mounts = NewNfsV3ConfigDetails()
+			mounts.ReadConf(strings.Join(MountsAllowed, ","), map2string(MountsOptions, ":", "", ","), MountsMandatory)
+
+			config = NewNfsV3Config(source, mounts)
+			logger.Debug("Debug config Initiated", lager.Data{"config": config, "source": source, "mount": mounts})
+			logger.Debug("Debug config updated", lager.Data{"config": config, "source": source, "mount": mounts})
+		})
+
+		It("should return empty allowed list", func() {
+			Expect(len(source.Allowed)).To(Equal(0))
+			Expect(len(mounts.Allowed)).To(Equal(0))
+		})
+
+		It("should flow the default list as forced", func() {
+			Expect(source.Forced).To(Equal(SourceOptions))
+			Expect(mounts.Forced).To(Equal(MountsOptions))
+		})
+
+		It("should return empty options list", func() {
+			Expect(len(source.Options)).To(Equal(0))
+			Expect(len(mounts.Options)).To(Equal(0))
+		})
+
+		It("should flow sloppy_mount as disabled", func() {
+			Expect(source.IsSloppyMount()).To(BeFalse())
+			Expect(mounts.IsSloppyMount()).To(BeFalse())
+		})
+
+		It("should return empty missing mandatory field", func() {
+			Expect(len(source.CheckMandatory())).To(Equal(0))
+			Expect(len(mounts.CheckMandatory())).To(Equal(0))
+		})
+	})
+})

--- a/nfs_v3_mounter.go
+++ b/nfs_v3_mounter.go
@@ -5,20 +5,21 @@ import (
 	"fmt"
 	"time"
 
-
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/nfsdriver"
 	"code.cloudfoundry.org/voldriver"
 	"code.cloudfoundry.org/voldriver/driverhttp"
 	"code.cloudfoundry.org/voldriver/invoker"
+	"strings"
 )
 
 type nfsV3Mounter struct {
 	invoker invoker.Invoker
+	config  Config
 }
 
-func NewNfsV3Mounter(invoker invoker.Invoker) nfsdriver.Mounter {
-	return &nfsV3Mounter{invoker}
+func NewNfsV3Mounter(invoker invoker.Invoker, config *Config) nfsdriver.Mounter {
+	return &nfsV3Mounter{invoker: invoker, config: *config}
 }
 
 func (m *nfsV3Mounter) Mount(env voldriver.Env, source string, target string, opts map[string]interface{}) error {
@@ -26,8 +27,37 @@ func (m *nfsV3Mounter) Mount(env voldriver.Env, source string, target string, op
 	logger.Info("start")
 	defer logger.Info("end")
 
-	logger.Debug("exec-mount", lager.Data{"source": source, "target": target})
-	_, err := m.invoker.Invoke(env, "fuse-nfs", []string{"-a", "-n", source, "-m", target})
+	if err := m.config.SetEntries(source, opts, []string{
+		"share", "mount", "kerberosPrincipal", "kerberosKeytab", "readonly",
+	}); err != nil {
+		logger.Debug("error-parse-entries", lager.Data{
+			"given_source":  source,
+			"given_target":  target,
+			"given_options": opts,
+			"config_source": m.config.source,
+			"config_mounts": m.config.mount,
+			"config_sloppy": m.config.sloppyMount,
+		})
+		return err
+	}
+
+	mountOptions := append([]string{
+		"-n", m.config.Share(source),
+		"-m", target,
+	}, m.config.Mount()...)
+
+	logger.Debug("parse-mount", lager.Data{
+		"given_source":  source,
+		"given_target":  target,
+		"given_options": opts,
+		"config_source": m.config.source,
+		"config_mounts": m.config.mount,
+		"config_sloppy": m.config.sloppyMount,
+		"mountOptions":  mountOptions,
+	})
+
+	logger.Debug("exec-mount", lager.Data{"params": strings.Join(mountOptions, ",")})
+	_, err := m.invoker.Invoke(env, "fuse-nfs", mountOptions)
 	return err
 }
 


### PR DESCRIPTION
# Add NFS Config
  * Add new file to regroup config struct & functions
  * Add init of config object in main.go 
  * Add call of elements of MountConfig in nfs_v3_mounter.go 

# Add DriverV3 Cmd Line options 
  * allowed-in-source with default value : uid,gid
  * default-in-source with default value : \<none\>
  * allowed-in-mount with default value: auto_cache
  * default-in-mount with default value: auto_cache=true